### PR TITLE
Add the possibility to download all startup logs

### DIFF
--- a/src/loader/loader.ts
+++ b/src/loader/loader.ts
@@ -57,7 +57,7 @@ export class Loader {
 
         const logsBlob = new Blob(this.logs, { type: 'text/plain' });
 
-        let innerHTML = `Press F5 to try again or click <a href='${href}'>here</a> to try again`;
+        let innerHTML = `Press F5 or click <a href='${href}'>here</a> to try again`;
         if (!isDebugMode) {
             innerHTML += ' in debug mode';
         }

--- a/src/loader/loader.ts
+++ b/src/loader/loader.ts
@@ -13,11 +13,13 @@
 import {DEBUG_PARAM} from '../workspace-loader';
 
 export class Loader {
+    private readonly logs: string[];
 
     /**
      * Initializes the Loader.
      */
     constructor() {
+        this.logs = [];
         /** Show the loader */
         setTimeout(() => {
             document.getElementById('workspace-loader')!.style.display = 'block';
@@ -37,22 +39,32 @@ export class Loader {
 
     showReload(): void {
         const reloadEl = document.getElementById('workspace-loader-reload');
-        if (reloadEl) {
-            const {pathname, search} = window.location;
-            const isDebugMode = search.includes(DEBUG_PARAM);
-            let href: string;
-            if (search === '') {
-                href = `${pathname}?${DEBUG_PARAM}`;
-            } else {
-                if (isDebugMode) {
-                    href = `${pathname}${search}`;
-                } else {
-                    href = `${pathname}${search}&${DEBUG_PARAM}`;
-                }
-            }
-            reloadEl.innerHTML = `Press F5 to try again or click <a href='${href}'>here</a> to try again${isDebugMode ? '' : ' in debug mode'}.`;
-            reloadEl.style.display = 'block';
+        if (!reloadEl) {
+            return;
         }
+        const { pathname, search } = window.location;
+        const isDebugMode = search.includes(DEBUG_PARAM);
+        let href: string;
+        if (search === '') {
+            href = `${pathname}?${DEBUG_PARAM}`;
+        } else {
+            if (isDebugMode) {
+                href = `${pathname}${search}`;
+            } else {
+                href = `${pathname}${search}&${DEBUG_PARAM}`;
+            }
+        }
+
+        const logsBlob = new Blob(this.logs, { type: 'text/plain' });
+
+        let innerHTML = `Press F5 to try again or click <a href='${href}'>here</a> to try again`;
+        if (!isDebugMode) {
+            innerHTML += ' in debug mode';
+        }
+        innerHTML += `. <a download='logs.txt' href='${URL.createObjectURL(logsBlob)}' id='download-link'>Download logs</a>`;
+
+        reloadEl.innerHTML = innerHTML;
+        reloadEl.style.display = 'block';
     }
 
     /**
@@ -61,8 +73,9 @@ export class Loader {
      * @param message message to log
      */
     log(message: string): HTMLElement {
+        this.logs.push(`${message}\r`);
         const container = document.getElementById('workspace-console-container')!;
-        if (container.firstChild && container.childElementCount > 500) {
+        if (container.firstChild && container.childElementCount > 200) {
             container.removeChild(container.firstChild);
         }
 

--- a/src/style.css
+++ b/src/style.css
@@ -39,17 +39,21 @@
     position: absolute;
     left: 0px;
     top: 0px;
-    width: 300px;
+    width: 400px;
     height: 30px;
     font-family: sans-serif;
     font-size: 14px;
     line-height: 30px;
-    text-align: center;
     color: #a0a9b7;
 }
 
 #workspace-loader-reload a {
     color: #a0a9b7;
+}
+
+#workspace-loader-reload #download-link {
+    margin-left: 15px;
+    color: #e22812;
 }
 
 #workspace-loader-progress {

--- a/src/style.css
+++ b/src/style.css
@@ -39,10 +39,11 @@
     position: absolute;
     left: 0px;
     top: 0px;
-    width: 400px;
+    width: 250px;
     height: 30px;
     font-family: sans-serif;
     font-size: 14px;
+    text-align: center;
     line-height: 30px;
     color: #a0a9b7;
 }
@@ -52,8 +53,7 @@
 }
 
 #workspace-loader-reload #download-link {
-    margin-left: 15px;
-    color: #e22812;
+    display: inline-block;
 }
 
 #workspace-loader-progress {
@@ -131,7 +131,7 @@
 }
 
 #workspace-console[max] {
-    height: calc(100% - 110px);
+    height: calc(100% - 125px);
 }
 
 @-webkit-keyframes dancing {

--- a/yarn.lock
+++ b/yarn.lock
@@ -239,16 +239,6 @@ acorn-walk@^6.0.1:
   resolved "https://registry.yarnpkg.com/acorn-walk/-/acorn-walk-6.2.0.tgz#123cb8f3b84c2171f1f7fb252615b1c78a6b1a8c"
   integrity sha512-7evsyfH1cLOCdAzZAd43Cic04yKydNx0cF+7tiA19p1XnLLPU4dpCQOqpjqwokFe//vS0QqfqqjCS2JkiIs0cA==
 
-acorn@^5.5.3:
-  version "5.7.3"
-  resolved "https://registry.yarnpkg.com/acorn/-/acorn-5.7.3.tgz#67aa231bf8812974b85235a96771eb6bd07ea279"
-  integrity sha512-T/zvzYRfbVojPWahDsE5evJdHb3oJoQfFbsrKM7w5Zcs++Tr257tia3BmMP8XYVjp1S9RZXQMh7gao96BlqZOw==
-
-acorn@^6.0.1, acorn@^6.2.1:
-  version "6.3.0"
-  resolved "https://registry.yarnpkg.com/acorn/-/acorn-6.3.0.tgz#0087509119ffa4fc0a0041d1e93a417e68cb856e"
-  integrity sha512-/czfa8BwS88b9gWQVhc8eknunSA2DoJpJyTQkhheIf5E48u1N0R4q/YxxsAeqRrmK9TQ/uYfgLDfZo91UlANIA==
-
 acorn@^6.4.1:
   version "6.4.1"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-6.4.1.tgz#531e58ba3f51b9dacb9a6646ca4debf5b14ca474"
@@ -3750,21 +3740,13 @@ js-tokens@^3.0.2:
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-3.0.2.tgz#9866df395102130e38f7f996bceb65443209c25b"
   integrity sha1-mGbfOVECEw449/mWvOtlRDIJwls=
 
-js-yaml@^3.13.1, js-yaml@^3.7.0:
+js-yaml@^3.13.1:
   version "3.13.1"
   resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.13.1.tgz#aff151b30bfdfa8e49e05da22e7415e9dfa37847"
   integrity sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==
   dependencies:
     argparse "^1.0.7"
     esprima "^4.0.0"
-
-js-yaml@~3.7.0:
-  version "3.7.0"
-  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.7.0.tgz#5c967ddd837a9bfdca5f2de84253abe8a1c03b80"
-  integrity sha1-XJZ93YN6m/3KXy3oQlOr6KHAO4A=
-  dependencies:
-    argparse "^1.0.7"
-    esprima "^2.6.0"
 
 jsbn@~0.1.0:
   version "0.1.1"
@@ -4274,25 +4256,10 @@ minimatch@^3.0.3, minimatch@^3.0.4:
   dependencies:
     brace-expansion "^1.1.7"
 
-minimist@0.0.8:
-  version "0.0.8"
-  resolved "https://registry.yarnpkg.com/minimist/-/minimist-0.0.8.tgz#857fcabfc3397d2625b8228262e86aa7a011b05d"
-  integrity sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=
-
-minimist@^1.1.1, minimist@^1.2.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.0.tgz#a35008b20f41383eec1fb914f4cd5df79a264284"
-  integrity sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=
-
 minimist@^1.2.2:
   version "1.2.5"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.5.tgz#67d66014b66a6a8aaa0c083c5fd58df4e4e97602"
   integrity sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==
-
-minimist@~0.0.1:
-  version "0.0.10"
-  resolved "https://registry.yarnpkg.com/minimist/-/minimist-0.0.10.tgz#de3f98543dbf96082be48ad1a0c7cda836301dcf"
-  integrity sha1-3j+YVD2/lggr5IrRoMfNqDYwHc8=
 
 minipass@^2.6.0, minipass@^2.8.6, minipass@^2.9.0:
   version "2.9.0"
@@ -5942,11 +5909,6 @@ send@0.17.1:
     on-finished "~2.3.0"
     range-parser "~1.2.1"
     statuses "~1.5.0"
-
-serialize-javascript@^1.4.0, serialize-javascript@^1.7.0:
-  version "1.9.1"
-  resolved "https://registry.yarnpkg.com/serialize-javascript/-/serialize-javascript-1.9.1.tgz#cfc200aef77b600c47da9bb8149c943e798c2fdb"
-  integrity sha512-0Vb/54WJ6k5v8sSWN09S0ora+Hnr+cX40r9F170nT+mSkaxltoE/7R3OrIdBSUv1OoiobH1QoWQbCnAO+e8J1A==
 
 serialize-javascript@^2.1.1:
   version "2.1.2"


### PR DESCRIPTION
Signed-off-by: Oleksii Orel <oorel@redhat.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum, you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
Add the possibility to download all startup logs.

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/16063
<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->

![Screenshot from 2020-03-24 02-18-20](https://user-images.githubusercontent.com/6310786/77378959-23acf380-6d80-11ea-822d-27ddf679b057.png)
