### PR TITLE
Fix refreshing of token after workspace start

### DIFF
--- a/src/workspace-loader.ts
+++ b/src/workspace-loader.ts
@@ -319,6 +319,7 @@ export class WorkspaceLoader {
                     this.keycloak.login();
                     reject(new Error('Failed to refresh token'));
                 });
+                return;
             }
 
             resolve(xhr);


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?

This PR brings fix that seems to be lost while moving `che-workspace-loader` into separate repository - see https://github.com/eclipse/che/pull/16332
