### PR TITLE
New buildx + matrix build

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -29,6 +29,8 @@ jobs:
       uses: crazy-max/ghaction-docker-buildx@v1.6.1
       with:
         buildx-version: v0.4.1
+    - name: "Docker prepare"
+      run: docker image prune -a -f
     - name: "Docker Quay.io Login"
       run:  docker login -u "${{ secrets.QUAY_USERNAME }}" -p "${{ secrets.QUAY_PASSWORD }}" quay.io
     - name: "Docker docker.io Login"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -29,8 +29,6 @@ jobs:
       uses: crazy-max/ghaction-docker-buildx@v1.6.1
       with:
         buildx-version: v0.4.1
-    - name: "Docker prepare"
-      run: docker image prune -a -f
     - name: "Docker Quay.io Login"
       run:  docker login -u "${{ secrets.QUAY_USERNAME }}" -p "${{ secrets.QUAY_PASSWORD }}" quay.io
     - name: "Docker docker.io Login"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -16,6 +16,7 @@ jobs:
   docker-build:
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         platform: [linux/amd64, linux/s390x]
     env:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -15,6 +15,9 @@ on:
 jobs:
   docker-build:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        platform: [linux/amd64, linux/s390x]
     env:
       IMAGE_FULL: quay.io/eclipse/che-workspace-loader:next
       CACHE_IMAGE_FULL: docker.io/cheincubator/che-workspace-loader:cache
@@ -22,9 +25,9 @@ jobs:
     - uses: actions/checkout@v2
       name: Checkout che-workspace-loader source code
     - name: Docker Buildx
-      uses: crazy-max/ghaction-docker-buildx@v1.4.0
+      uses: crazy-max/ghaction-docker-buildx@v1.6.1
       with:
-        version: v0.3.1
+        buildx-version: v0.4.1
     - name: "Docker prepare"
       run: docker image prune -a -f
     - name: "Docker Quay.io Login"
@@ -32,6 +35,6 @@ jobs:
     - name: "Docker docker.io Login"
       run:  docker login -u "${{ secrets.DOCKERHUB_USERNAME }}" -p "${{ secrets.DOCKERHUB_PASSWORD }}" docker.io
     - name: "Docker build"
-      run: docker buildx build --platform linux/amd64,linux/s390x --cache-from="type=registry,ref=${CACHE_IMAGE_FULL}" --cache-to="type=registry,ref=${CACHE_IMAGE_FULL},mode=max" -t ${IMAGE_FULL}  -f apache.Dockerfile --push .
+      run: docker buildx build --platform ${{ matrix.platform}} --cache-from="type=registry,ref=${CACHE_IMAGE_FULL}" --cache-to="type=registry,ref=${CACHE_IMAGE_FULL},mode=max" -t ${IMAGE_FULL}  -f apache.Dockerfile --push .
     - name: "Docker Logout"
       run: docker logout

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -35,7 +35,11 @@ jobs:
       run:  docker login -u "${{ secrets.QUAY_USERNAME }}" -p "${{ secrets.QUAY_PASSWORD }}" quay.io
     - name: "Docker docker.io Login"
       run:  docker login -u "${{ secrets.DOCKERHUB_USERNAME }}" -p "${{ secrets.DOCKERHUB_PASSWORD }}" docker.io
-    - name: "Docker build"
-      run: docker buildx build --platform ${{ matrix.platform}} --cache-from="type=registry,ref=${CACHE_IMAGE_FULL}" --cache-to="type=registry,ref=${CACHE_IMAGE_FULL},mode=max" -t ${IMAGE_FULL}  -f apache.Dockerfile --push .
+    - name: "Docker build with cache"
+      uses: nick-invision/retry@v1
+      with:
+        timeout_minutes: 20
+        max_attempts: 5
+        command: docker buildx build --platform ${{ matrix.platform}} --cache-from="type=registry,ref=${CACHE_IMAGE_FULL}" --cache-to="type=registry,ref=${CACHE_IMAGE_FULL},mode=max" -t ${IMAGE_FULL}  -f apache.Dockerfile --push .
     - name: "Docker Logout"
       run: docker logout

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -16,6 +16,7 @@ jobs:
   docker-build:
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         platform: [linux/amd64, linux/s390x]
     env:

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -30,6 +30,8 @@ jobs:
       uses: crazy-max/ghaction-docker-buildx@v1.6.1
       with:
         buildx-version: v0.4.1
+    - name: "Docker prepare"
+      run: docker image prune -a -f
     - name: "Docker build without cache"
       if: ${{ matrix.layerscaching == false}}
       run: docker buildx build --platform ${{ matrix.platform}} -t ${IMAGE_FULL}  -f apache.Dockerfile .

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -30,11 +30,9 @@ jobs:
       uses: crazy-max/ghaction-docker-buildx@v1.6.1
       with:
         buildx-version: v0.4.1
-    - name: "Docker prepare"
-      run: docker image prune -a -f
     - name: "Docker build without cache"
-      if: ${{ matrix.layerscaching == 'false'}}
+      if: ${{ matrix.layerscaching == false}}
       run: docker buildx build --platform ${{ matrix.platform}} -t ${IMAGE_FULL}  -f apache.Dockerfile .
     - name: "Docker build with cache"
-      if: ${{ matrix.layerscaching == 'true'}}
+      if: ${{ matrix.layerscaching == true}}
       run: docker buildx build --platform ${{ matrix.platform}} --cache-from="type=registry,ref=${CACHE_IMAGE_FULL}" -t ${IMAGE_FULL}  -f apache.Dockerfile .

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -33,9 +33,8 @@ jobs:
     - name: "Docker prepare"
       run: docker image prune -a -f
     - name: "Docker build without cache"
-      if: ${{ matrix.layerscaching== 'false'}}
+      if: ${{ matrix.layerscaching == 'false'}}
       run: docker buildx build --platform ${{ matrix.platform}} -t ${IMAGE_FULL}  -f apache.Dockerfile .
     - name: "Docker build with cache"
-      if: ${{ matrix.layerscaching== 'true'}}
+      if: ${{ matrix.layerscaching == 'true'}}
       run: docker buildx build --platform ${{ matrix.platform}} --cache-from="type=registry,ref=${CACHE_IMAGE_FULL}" -t ${IMAGE_FULL}  -f apache.Dockerfile .
-      

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -19,6 +19,7 @@ jobs:
       fail-fast: false
       matrix:
         platform: [linux/amd64, linux/s390x]
+        layerscaching: [true, false]
     env:
       IMAGE_FULL: quay.io/eclipse/che-workspace-loader:next
       CACHE_IMAGE_FULL: docker.io/cheincubator/che-workspace-loader:cache
@@ -31,5 +32,10 @@ jobs:
         buildx-version: v0.4.1
     - name: "Docker prepare"
       run: docker image prune -a -f
-    - name: "Docker build"
+    - name: "Docker build without cache"
+      if: ${{ matrix.layerscaching== 'false'}}
       run: docker buildx build --platform ${{ matrix.platform}} -t ${IMAGE_FULL}  -f apache.Dockerfile .
+    - name: "Docker build with cache"
+      if: ${{ matrix.layerscaching== 'true'}}
+      run: docker buildx build --platform ${{ matrix.platform}} --cache-from="type=registry,ref=${CACHE_IMAGE_FULL}" -t ${IMAGE_FULL}  -f apache.Dockerfile .
+      

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -34,7 +34,15 @@ jobs:
       run: docker image prune -a -f
     - name: "Docker build without cache"
       if: ${{ matrix.layerscaching == false}}
-      run: docker buildx build --platform ${{ matrix.platform}} -t ${IMAGE_FULL}  -f apache.Dockerfile .
+      uses: nick-invision/retry@v1
+      with:
+        timeout_minutes: 10
+        max_attempts: 3
+        command: docker buildx build --platform ${{ matrix.platform}} -t ${IMAGE_FULL}  -f apache.Dockerfile .
     - name: "Docker build with cache"
       if: ${{ matrix.layerscaching == true}}
-      run: docker buildx build --platform ${{ matrix.platform}} --cache-from="type=registry,ref=${CACHE_IMAGE_FULL}" -t ${IMAGE_FULL}  -f apache.Dockerfile .
+      uses: nick-invision/retry@v1
+      with:
+        timeout_minutes: 10
+        max_attempts: 3
+        command: docker buildx build --platform ${{ matrix.platform}} --cache-from="type=registry,ref=${CACHE_IMAGE_FULL}" -t ${IMAGE_FULL}  -f apache.Dockerfile .

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -37,12 +37,12 @@ jobs:
       uses: nick-invision/retry@v1
       with:
         timeout_minutes: 10
-        max_attempts: 3
+        max_attempts: 5
         command: docker buildx build --platform ${{ matrix.platform}} -t ${IMAGE_FULL}  -f apache.Dockerfile .
     - name: "Docker build with cache"
       if: ${{ matrix.layerscaching == true}}
       uses: nick-invision/retry@v1
       with:
         timeout_minutes: 10
-        max_attempts: 3
+        max_attempts: 5
         command: docker buildx build --platform ${{ matrix.platform}} --cache-from="type=registry,ref=${CACHE_IMAGE_FULL}" -t ${IMAGE_FULL}  -f apache.Dockerfile .

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -15,6 +15,9 @@ on:
 jobs:
   docker-build:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        platform: [linux/amd64, linux/s390x]
     env:
       IMAGE_FULL: quay.io/eclipse/che-workspace-loader:next
       CACHE_IMAGE_FULL: docker.io/cheincubator/che-workspace-loader:cache
@@ -22,10 +25,10 @@ jobs:
     - uses: actions/checkout@v2
       name: Checkout che-workspace-loader source code
     - name: Docker Buildx
-      uses: crazy-max/ghaction-docker-buildx@v1.4.0
+      uses: crazy-max/ghaction-docker-buildx@v1.6.1
       with:
-        version: v0.3.1
+        buildx-version: v0.4.1
     - name: "Docker prepare"
       run: docker image prune -a -f
     - name: "Docker build"
-      run: docker buildx build --platform linux/amd64,linux/s390x --cache-from="type=registry,ref=${CACHE_IMAGE_FULL}" -t ${IMAGE_FULL}  -f apache.Dockerfile .
+      run: docker buildx build --platform ${{ matrix.platform}} -t ${IMAGE_FULL}  -f apache.Dockerfile .


### PR DESCRIPTION
### What does this PR do?
- Upgrade of builds to v0.4.1
- Upgrade of ghaction-docker-buildx to 1.6.1
- matrix build for linux/amd64, linux/s390x platform in ci and pr checks
- matrix build with cache for pr checks 
- 5 retries for ci and  pr check

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/16983