### PR TITLE
Added retry timeout 60 sec for CI push job

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -38,6 +38,7 @@ jobs:
       with:
         timeout_minutes: 20
         max_attempts: 5
+        retry_wait_seconds: 60
         command: docker buildx build --platform linux/amd64,linux/s390x --cache-from="type=registry,ref=${CACHE_IMAGE_FULL}" --cache-to="type=registry,ref=${CACHE_IMAGE_FULL},mode=max" -t ${IMAGE_FULL}  -f apache.Dockerfile --push .
     - name: "Docker Logout"
       run: docker logout


### PR DESCRIPTION
### What does this PR do?
Added retry timeout 60 sec for CI push job

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/16983