### PR TITLE
Added support for ppc64le in Github Actions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -39,6 +39,6 @@ jobs:
         timeout_minutes: 20
         max_attempts: 5
         retry_wait_seconds: 60
-        command: docker buildx build --platform linux/amd64,linux/s390x -t ${IMAGE_FULL}  -f apache.Dockerfile --push .
+        command: docker buildx build --platform linux/amd64,linux/s390x,linux/ppc64le -t ${IMAGE_FULL}  -f apache.Dockerfile --push .
     - name: "Docker Logout"
       run: docker logout

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        platform: [linux/amd64, linux/s390x]
+        platform: [linux/amd64, linux/s390x, linux/ppc64le]
         layerscaching: [true, false]
     env:
       IMAGE_FULL: quay.io/eclipse/che-workspace-loader:next


### PR DESCRIPTION
Signed-off-by: Vikas Kumar <kumar.vikas@in.ibm.com>

### What does this PR do?
Adds ppc64le support in docker buildx command for Github actions workflow.

### What issues does this PR fix or reference?
This PR is part of [this](https://github.com/eclipse/che/issues/16655) initiative.