### PR TITLE
Fix direct URL to open workspaces like /namespace/workspaceName

### DIFF
--- a/src/workspace-loader.ts
+++ b/src/workspace-loader.ts
@@ -287,10 +287,6 @@ export class WorkspaceLoader {
             }
         }
 
-        if (workspace.links) {
-            this.openURL(workspace.links.ide + this.getQueryString());
-        }
-
         throw new Error('Don\'t know what to open, IDE url is not defined.');
     }
 


### PR DESCRIPTION
### What does this PR do?
Along with https://github.com/eclipse/che/pull/16127/files it's supposed to fix direct URL to open workspaces like /namespace/workspaceName.

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/15733

