### PR TITLE
Сhanged badge in README.md to show the status of CI workflow of GH actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-![CI](https://github.com/eclipse/che-workspace-loader/workflows/CI/badge.svg)
+![Next dockerimage](https://github.com/eclipse/che-workspace-loader/workflows/CI/badge.svg)
 
 `che-workspace-loader` is sub-project of [Eclipse Che](https://github.com/eclipse/che) project.
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,4 @@
-[![Master Build Status](https://ci.centos.org/buildStatus/icon?subject=master&job=devtools-che-workspace-loader-che-build-master)](https://ci.centos.org/job/devtools-che-workspace-loader-che-build-master/)
-[![Nightly Build Status](https://ci.centos.org/buildStatus/icon?subject=nightly&job=devtools-che-workspace-loader-che-nightly)](https://ci.centos.org/job/devtools-che-workspace-loader-che-nightly/)
-[![Release Build Status](https://ci.centos.org/buildStatus/icon?subject=release&job=devtools-che-workspace-loader-che-release)](https://ci.centos.org/job/devtools-che-workspace-loader-che-release/)
+![CI](https://github.com/eclipse/che-workspace-loader/workflows/CI/badge.svg)
 
 `che-workspace-loader` is sub-project of [Eclipse Che](https://github.com/eclipse/che) project.
 


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?

Deletes badges of CentOs CI jobs and adds a new badge to show the status of CI workflow.
